### PR TITLE
Fix build errors on macOS: Undefined symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,22 @@ option(FTXUI_ENABLE_INSTALL OFF)
 add_subdirectory(3rd_party/FTXUI)
 
 add_executable(audiovis_cli main.cpp)
-target_link_libraries(audiovis_cli PRIVATE
-        ftxui::screen
-        ftxui::dom
-        ftxui::component
-        LabSound)
+
+if(CMAKE_HOST_APPLE)
+        target_link_libraries(audiovis_cli PRIVATE
+                ftxui::screen
+                ftxui::dom
+                ftxui::component
+                LabSound
+                "-framework CoreFoundation"
+                "-framework CoreAudio"
+                "-framework Accelerate"
+        )
+else()
+        target_link_libraries(audiovis_cli PRIVATE
+                ftxui::screen
+                ftxui::dom
+                ftxui::component
+                LabSound
+        )
+endif()


### PR DESCRIPTION
[build] Undefined symbols for architecture x86_64:
[build]   "_AudioDeviceCreateIOProcID", referenced from:
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioDeviceDestroyIOProcID", referenced from:
[build]       RtApiCore::closeStream() in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioDeviceStart", referenced from:
[build]       RtApiCore::startStream() in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioDeviceStop", referenced from:
[build]       RtApiCore::closeStream() in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::stopStream() in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioObjectAddPropertyListener", referenced from:
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioObjectGetPropertyData", referenced from:
[build]       RtApiCore::getDefaultInputDevice() in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::getDefaultOutputDevice() in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::getDeviceInfo(unsigned int) in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]       rateListener(unsigned int, unsigned int, AudioObjectPropertyAddress const*, void*) in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioObjectGetPropertyDataSize", referenced from:
[build]       RtApiCore::getDeviceCount() in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::getDeviceInfo(unsigned int) in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioObjectHasProperty", referenced from:
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioObjectRemovePropertyListener", referenced from:
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::closeStream() in LabSound_d(RtAudio.cpp.o)
[build]   "_AudioObjectSetPropertyData", referenced from:
[build]       RtApiCore::RtApiCore() in LabSound_d(RtAudio.cpp.o)
[build]       RtApiCore::probeDeviceOpen(unsigned int, RtApi::StreamMode, unsigned int, unsigned int, unsigned int, unsigned long, unsigned int*, RtAudio::StreamOptions*) in LabSound_d(RtAudio.cpp.o)
[build]   "_CFRelease", referenced from:
[build]       RtApiCore::getDeviceInfo(unsigned int) in LabSound_d(RtAudio.cpp.o)
[build]   "_CFStringGetCString", referenced from:
[build]       RtApiCore::getDeviceInfo(unsigned int) in LabSound_d(RtAudio.cpp.o)
[build]   "_CFStringGetLength", referenced from:
[build]       RtApiCore::getDeviceInfo(unsigned int) in LabSound_d(RtAudio.cpp.o)
[build]   "_CFStringGetSystemEncoding", referenced from:
[build]       RtApiCore::getDeviceInfo(unsigned int) in LabSound_d(RtAudio.cpp.o)
[build]   "_vDSP_create_fftsetup", referenced from:
[build]       lab::FFTFrame::fftSetupForSize(int) in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]   "_vDSP_ctoz", referenced from:
[build]       lab::FFTFrame::computeForwardFFT(float const*) in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]   "_vDSP_destroy_fftsetup", referenced from:
[build]       lab::FFTFrame::cleanup() in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]   "_vDSP_fft_zrip", referenced from:
[build]       lab::FFTFrame::computeForwardFFT(float const*) in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]       lab::FFTFrame::computeInverseFFT(float*) in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]   "_vDSP_maxmgv", referenced from:
[build]       lab::VectorMath::vmaxmgv(float const*, int, float*, int) in LabSound_d(VectorMath.cpp.o)
[build]   "_vDSP_svesq", referenced from:
[build]       lab::VectorMath::vsvesq(float const*, int, float*, int) in LabSound_d(VectorMath.cpp.o)
[build]   "_vDSP_vadd", referenced from:
[build]       lab::VectorMath::vadd(float const*, int, float const*, int, float*, int, int) in LabSound_d(VectorMath.cpp.o)
[build]   "_vDSP_vclip", referenced from:
[build]       lab::VectorMath::vclip(float const*, int, float const*, float const*, float*, int, int) in LabSound_d(VectorMath.cpp.o)
[build]   "_vDSP_vmul", referenced from:
[build]       lab::VectorMath::vmul(float const*, int, float const*, int, float*, int, int) in LabSound_d(VectorMath.cpp.o)
[build]   "_vDSP_vsma", referenced from:
[build]       lab::VectorMath::vsma(float const*, int, float const*, float*, int, int) in LabSound_d(VectorMath.cpp.o)
[build]   "_vDSP_vsmul", referenced from:
[build]       lab::VectorMath::vsmul(float const*, int, float const*, float*, int, int) in LabSound_d(VectorMath.cpp.o)
[build]       lab::FFTFrame::computeInverseFFT(float*) in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]   "_vDSP_ztoc", referenced from:
[build]       lab::FFTFrame::computeInverseFFT(float*) in LabSound_d(FFTFrameAppleAcclerate.cpp.o)
[build]   "_vDSP_zvmul", referenced from:
[build]       lab::VectorMath::zvmul(float const*, float const*, float const*, float const*, float*, float*, int) in LabSound_d(VectorMath.cpp.o)